### PR TITLE
Update WebAssembly dependencies to .NET 9 versions

### DIFF
--- a/src/PQDIFExplorer.Web/PQDIFExplorer.Web.csproj
+++ b/src/PQDIFExplorer.Web/PQDIFExplorer.Web.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Gemstone.Numeric" Version="1.0.117" />
     <PackageReference Include="Gemstone.PQDIF" Version="1.0.117" />
     <PackageReference Include="Gemstone.Web.Razor" Version="1.0.117" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.10" PrivateAssets="all" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/PQDIFExplorer.Web/web.published.config
+++ b/src/PQDIFExplorer.Web/web.published.config
@@ -36,11 +36,5 @@
         </rule>
       </rules>
     </rewrite>
-    <handlers>
-      <clear />
-      <add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read" />
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
-    </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" />
   </system.webServer>
 </configuration>


### PR DESCRIPTION
The dependencies need to be updated for the application to work at all against .NET 9.

The `web.config` change just removes an unnecessary dependency on the .NET 9 Hosting Bundle, as there is no ASP.NET Core component to this app. So long as `index.html` can be served, the app should function in modern browsers.